### PR TITLE
Adding a plotting switch for libraries needed for plotting.

### DIFF
--- a/lib/cuckoo/common/config.py
+++ b/lib/cuckoo/common/config.py
@@ -72,3 +72,4 @@ def parse_options(options):
 def emit_options(options):
     """Emit the analysis options from a dictionary to a string."""
     return ",".join("%s=%s" % (k, v) for k, v in options.items())
+

--- a/lib/cuckoo/common/constants.py
+++ b/lib/cuckoo/common/constants.py
@@ -8,6 +8,8 @@ import os
 _current_dir = os.path.abspath(os.path.dirname(__file__))
 CUCKOO_ROOT = os.path.normpath(os.path.join(_current_dir, "..", "..", ".."))
 
+print os.listdir(CUCKOO_ROOT + "/" + "sample_data/dict")
+
 CUCKOO_VERSION = "2.0-dev"
 CUCKOO_GUEST_PORT = 8000
 CUCKOO_GUEST_INIT = 0x001

--- a/modules/processing/cuckooml.py
+++ b/modules/processing/cuckooml.py
@@ -797,6 +797,13 @@ class ML(object):
 
     def detect_abnormal_behaviour(self, count_dataset=None, figures=True):
         """Detect samples that behave significantly different than others."""
+        
+        # Safety check for plotting
+        if not Config("cuckooml").cuckooml.plotting and figures:
+            print >> sys.stderr, "Warning: 'plotting' and 'figures' do not match. Plotting modules might not be imported."
+            figures = False
+
+
         if count_dataset is None:
             # Pull all count features
             count_features = self.feature_category(":count:")
@@ -1133,6 +1140,13 @@ class ML(object):
 
     def clustering_label_distribution(self, clustering, labels, plot=False):
         """Get statistics about number of ground truth labels per cluster."""
+        
+        # Safety check for plotting
+        if not Config("cuckooml").cuckooml.plotting and plot:
+            print >> sys.stderr, "Warning: 'plotting' and 'plot' do not match. Plotting modules might not be imported."
+            plot = False
+
+
         cluster_ids = set(clustering["label"].tolist())
         labels_ids = set(labels["label"].tolist())
         cluster_distribution = {}


### PR DESCRIPTION
As mentioned by So-Cool in enhancement feature #15 , some users might need only textual outputs. Hence a plotting switch checking for  imports of plotting libraries separately.